### PR TITLE
Visual Studio support, tile-flipping and drawing offset for tilesets

### DIFF
--- a/src/tmxparser.cpp
+++ b/src/tmxparser.cpp
@@ -545,7 +545,15 @@ TmxReturn _parseLayerXmlTileNode(tinyxml2::XMLElement* element, const TmxTileset
 {
 	TmxReturn error = TmxReturn::kSuccess;
 
-	outTile->gid = element->UnsignedAttribute("gid");
+	auto gid = element->UnsignedAttribute("gid");
+	auto flipXFlag = 0x80000000;
+	auto flipYFlag = 0x40000000;
+	auto flipDiagonalFlag = 0x20000000;
+
+	outTile->flipX = (gid & flipXFlag ? true : false);
+	outTile->flipY = (gid & flipYFlag ? true : false);
+	outTile->flipDiagonal = (gid & flipDiagonalFlag ? true : false);
+	outTile->gid = (gid & ~(flipXFlag | flipYFlag | flipDiagonalFlag));
 
 	return _calculateTileIndices(tilesets, outTile);
 }

--- a/src/tmxparser.cpp
+++ b/src/tmxparser.cpp
@@ -137,6 +137,7 @@ TmxReturn _parseLayerXmlTileNode(tinyxml2::XMLElement* element, const TmxTileset
 TmxReturn _calculateTileIndices(const TmxTilesetCollection_t& tilesets, TmxLayerTile* outTile);
 TmxReturn _parseObjectGroupNode(tinyxml2::XMLElement* element, TmxObjectGroup* outObjectGroup);
 TmxReturn _parseObjectNode(tinyxml2::XMLElement* element, TmxObject* outObj);
+TmxReturn _parseOffsetNode(tinyxml2::XMLElement* element, TmxOffset* offset);
 
 
 TmxReturn parseFromFile(const std::string& fileName, TmxMap* outMap, const std::string& tilesetPath)
@@ -340,6 +341,11 @@ TmxReturn _parseTilesetNode(tinyxml2::XMLElement* element, TmxTileset* outTilese
 			return error;
 		}
 
+		if (element->FirstChildElement("tileoffset") != NULL)
+		{
+			_parseOffsetNode(element->FirstChildElement("tileoffset"), &outTileset->offset);
+		}
+
 		for (tinyxml2::XMLElement* child = element->FirstChildElement("tile"); child != NULL; child = child->NextSiblingElement("tile"))
 		{
 			TmxTileDefinition tileDef;
@@ -422,7 +428,7 @@ TmxReturn _parseLayerNode(tinyxml2::XMLElement* element, const TmxTilesetCollect
 
 	outLayer->name = element->Attribute("name");
 	outLayer->opacity = element->FloatAttribute("opacity");
-	outLayer->visible = element->IntAttribute("visible");
+	outLayer->visible = (element->IntAttribute("visible") == 1 ? true : false);
 	outLayer->width = element->UnsignedAttribute("width");
 	outLayer->height = element->UnsignedAttribute("height");
 
@@ -696,9 +702,9 @@ TmxReturn _parseObjectNode(tinyxml2::XMLElement* element, TmxObject* outObj)
 			std::istringstream pointStringString(pairToken);
 			std::string pointToken;
 			std::getline(pointStringString, pointToken, ',');
-			pair.first = atof(pointToken.c_str());
+			pair.first = (float)atof(pointToken.c_str());
 			std::getline(pointStringString, pointToken, ',');
-			pair.second = atof(pointToken.c_str());
+			pair.second = (float)atof(pointToken.c_str());
 
 			outObj->shapePoints.push_back(pair);
 		}
@@ -730,8 +736,8 @@ TmxReturn calculateTileCoordinatesUV(const TmxTileset& tileset,  unsigned int ti
 	if (flipY)
 	{
 		float tmpV = v;
-		v = 1.0 - v2;
-		v2 = 1.0 - tmpV;
+		v = 1.f - v2;
+		v2 = 1.f - tmpV;
 	}
 
 	outRect.u = u;
@@ -742,5 +748,26 @@ TmxReturn calculateTileCoordinatesUV(const TmxTileset& tileset,  unsigned int ti
 	return kSuccess;
 }
 
+tmxparser::TmxReturn _parseOffsetNode(tinyxml2::XMLElement* element, TmxOffset* offset)
+{
+	TmxReturn error = TmxReturn::kSuccess;
+
+	offset->x = 0;
+	offset->y = 0;
+
+	if (element->Attribute("x"))
+	{
+		offset->x = element->IntAttribute("x");
+	}
+
+	if (element->Attribute("y"))
+	{
+		offset->y = element->IntAttribute("y");
+	}
+
+	return error;
+}
 
 }
+
+

--- a/src/tmxparser.h
+++ b/src/tmxparser.h
@@ -171,7 +171,7 @@ typedef struct
 {
 	int x;
 	int y;
-} TmxTileOffset;
+} TmxOffset;
 
 
 typedef struct
@@ -192,6 +192,7 @@ typedef struct
 	unsigned int tileHeight;
 	unsigned int tileSpacingInImage;
 	unsigned int tileMarginInImage;
+	TmxOffset offset;
 
 	unsigned int rowCount; /// based on image width and tile spacing/margins
 	unsigned int colCount; /// based on image height and tile spacing/margins

--- a/src/tmxparser.h
+++ b/src/tmxparser.h
@@ -210,6 +210,7 @@ typedef struct
 	unsigned int gid;
 	unsigned int tilesetIndex;
 	unsigned int tileFlatIndex;
+	bool flipX, flipY, flipDiagonal;
 } TmxLayerTile;
 
 

--- a/src/tmxparser.h
+++ b/src/tmxparser.h
@@ -28,10 +28,20 @@ THE SOFTWARE.
 
 #include <string>
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
+#if defined __GXX_EXPERIMENTAL_CXX0X__ || (_MSC_VER >= 1800)
 #include <unordered_map>
+template <typename TKey, typename TValue>
+struct Map
+{
+	typedef std::unordered_map<TKey, TValue> type;
+};
 #else
 #include <map>
+template <typename TKey, typename TValue>
+struct Map
+{
+	typedef std::map<TKey, TValue> type;
+};
 #endif
 
 #include <vector>
@@ -56,11 +66,7 @@ typedef enum
 } TmxReturn;
 
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
-typedef std::unordered_map<std::string, std::string> TmxPropertyMap_t;
-#else
-typedef std::map<std::string, std::string> TmxPropertyMap_t;
-#endif
+typedef Map<std::string, std::string>::type TmxPropertyMap_t;
 
 
 typedef unsigned int TileId_t;
@@ -158,7 +164,7 @@ typedef struct
 } TmxTileDefinition;
 
 
-typedef std::unordered_map<unsigned int, TmxTileDefinition> TmxTileDefinitionMap_t;
+typedef Map<unsigned int, TmxTileDefinition>::type TmxTileDefinitionMap_t;
 
 
 typedef struct


### PR DESCRIPTION
There was an compilation error if \__GXX_EXPERIMENTAL_CXX0X__ was not set.
I changed the include statement for the maps. Now it also works with Visual Studio 2013 or higher. 
Then I added the possibility to set an offset for specific tilesets. For this I renamed the struct TmxTileOffset (which was not used anyways) to TmxOffset and added it to the Tileset-struct TmxTileSet. In Source file the offset is now read if present.
The last change was in struct TmxTile. Here I added the flip-bits. For more infos, please read here: https://github.com/bjorn/tiled/wiki/TMX-Map-Format, under "Tile flipping".